### PR TITLE
Fix issues in `pylint.yml` and JSlint error for no files found

### DIFF
--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           FILES=$(find . -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.vue" -o -name "*.css" -o -name "*.html" -o -name "*.json" \))
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs prettier --check --log-level debug
+            echo "$FILES" | xargs prettier --check --log-level debug --write
           else
             echo "No matching files found for linting."
           fi

--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           FILES=$(find . -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.vue" -o -name "*.css" -o -name "*.html" -o -name "*.json" \))
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs prettier --check --log-level debug --write
+            echo "$FILES" | xargs prettier --log-level debug --write
           else
             echo "No matching files found for linting."
           fi

--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -23,7 +23,13 @@ jobs:
         run: npm install -g prettier
 
       - name: Run Prettier (JS Linting)
-        run: prettier --check '**/*.{js,ts,jsx,tsx,vue,css,html,json}' --log-level debug --write
+        run: |
+          FILES=$(find . -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.vue" -o -name "*.css" -o -name "*.html" -o -name "*.json" \))
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | xargs prettier --check --log-level debug
+          else
+            echo "No matching files found for linting."
+          fi
 
       - name: Fail on Lint Errors
         if: failure()

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,13 +22,27 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 black
+          pip install flake8 black diff-cover
 
       - name: Configure Flake8
-        run: echo -e "[flake8]\nmax-line-length = 256\nindent-size = 4" > .flake8
+        run: |
+          echo "[flake8]" > .flake8
+          echo "max-line-length = 256" >> .flake8
+          echo "indent-size = 4" >> .flake8
 
-      - name: Run Flake8 (Python Linting)
-        run: flake8 . --count --show-source --statistics
+      - name: Get changed Python files
+        id: get_diff
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} -- '*.py' | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
-      - name: Check Python Formatting with Black
-        run: black --check --diff --line-length 256 --target-version py310 --skip-string-normalization --fast . || true
+      - name: Run Flake8 on changed files
+        if: steps.get_diff.outputs.changed_files != ''
+        run: |
+          echo "Linting changed files: ${{ steps.get_diff.outputs.changed_files }}"
+          flake8 ${{ steps.get_diff.outputs.changed_files }}
+
+      - name: Check Python Formatting with Black (changed files only)
+        if: steps.get_diff.outputs.changed_files != ''
+        run: |
+          black --check --diff --line-length 256 --target-version py310 --skip-string-normalization --fast ${{ steps.get_diff.outputs.changed_files }}


### PR DESCRIPTION
Currently, the script picks up code from all the existing python files in the repository and not just the files changed, which was wrong.

This new patch picks up only select code from the current PR from the diff and tries linting it.