### PR TITLE
chore: add Ruff, pre-commit, Commitlint, update README

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 256
-indent-style = tab
-tab-size = 4
-exclude = .git,__pycache__,venv,.venv
-ignore = W191,E101,W503

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+**Description**
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+**Type of change**
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+**Checklist:**
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+
+**Screenshots (if applicable)**

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,7 +3,7 @@ name: Python Lint & Security Scan
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [develop, ValiSpect]
+    branches: [develop, main, development]
 
 jobs:
   lint:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,13 +1,13 @@
-name: Python Lint Check
+name: Python Lint & Security Scan
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [develop, development, main, master]
+    branches: [develop, ValiSpect]
 
 jobs:
-  python-lint:
-    name: Python Linting
+  lint:
+    name: Python Lint & Security Scan
     runs-on: ubuntu-latest
 
     steps:
@@ -19,30 +19,21 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install Python Dependencies
+      - name: Install Tools
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 black diff-cover
+          pip install ruff semgrep
 
-      - name: Configure Flake8
-        run: |
-          echo "[flake8]" > .flake8
-          echo "max-line-length = 256" >> .flake8
-          echo "indent-size = 4" >> .flake8
-
-      - name: Get changed Python files
+      - name: Get Changed Python Files
         id: get_diff
         run: |
           git fetch origin ${{ github.base_ref }}
           echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} -- '*.py' | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
-      - name: Run Flake8 on changed files
+      - name: Run Ruff Lint Check
         if: steps.get_diff.outputs.changed_files != ''
         run: |
           echo "Linting changed files: ${{ steps.get_diff.outputs.changed_files }}"
-          flake8 ${{ steps.get_diff.outputs.changed_files }}
+          ruff check ${{ steps.get_diff.outputs.changed_files }}
 
-      - name: Check Python Formatting with Black (changed files only)
-        if: steps.get_diff.outputs.changed_files != ''
-        run: |
-          black --check --diff --line-length 256 --target-version py310 --skip-string-normalization --fast ${{ steps.get_diff.outputs.changed_files }}
+     

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+exclude: "node_modules|.git"
+default_stages: [pre-commit]
+fail_fast: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        files: ".*"
+        exclude: ".*json$|.*txt$|.*csv|.*md|.*svg"
+      - id: no-commit-to-branch
+        args: ["--branch", "development"]
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-ast
+      - id: check-json
+      - id: check-toml
+      - id: debug-statements
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.6
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+
+      - id: ruff-format
+        name: "Check Python code formatting"
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, vue, scss, css]
+        exclude: |
+          (?x)^(
+            public/asset/.*|
+            public/dist/.*|
+            .*node_modules.*|
+            .*\.json$
+          )$
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.23.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies:
+          - "@commitlint/config-conventional"

--- a/README.md
+++ b/README.md
@@ -1,66 +1,106 @@
-# [App Name]
+# .github Configuration
+![Python Lint](https://github.com/Ambibuzz/.github/actions/workflows/pylint.yml/badge.svg)
+![JS Lint](https://github.com/Ambibuzz/.github/actions/workflows/jslint.yml/badge.svg)
+![Review Workflow](https://github.com/Ambibuzz/.github/actions/workflows/review.yml/badge.svg)
+![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)
+![Conventional Commits](https://img.shields.io/badge/commits-conventional-blue?logo=git&logoColor=white)
 
-## Overview
+This repository serves as the central configuration and health repository for **Ambibuzz Technologies LLP**. It mirrors the special `.github` repository pattern supported by GitHub to provide default community health files and configurations for the organization.
+## Table of Contents
 
-[App Name] is a Frappe-based application developed and maintained by **Ambibuzz Technologies LLP**. This app is designed to enhance and extend the capabilities of the Frappe framework, providing seamless integration and functionality.
+- [Purpose](#purpose)
+- [Tools & Configurations](#tools--configurations)
+  - [Python Linting & Formatting (`ruff.toml`)](#1-python-linting--formatting-rufftoml)
+  - [Commit Message Linting (`commitlint.config.js`)](#2-commit-message-linting-commitlintconfigjs)
+  - [Pre-commit Hooks (`.pre-commit-config.yaml`)](#3-pre-commit-hooks-pre-commit-configyaml)
+- [Workflows (GitHub Actions)](#workflows-github-actions)
+- [Setup Instructions](#setup-instructions)
+- [Repository Structure](#repository-structure)
+- [Contact](#contact)
+## Purpose
 
-## Features
+The primary purpose of this repository is to store reusable configurations and workflows that can be inherited or referenced by other repositories within the organization. This ensures consistency in coding standards, commit messages, and CI/CD processes.
 
-- Feature 1
-- Feature 2
-- Feature 3
+## Tools & Configurations
 
-## Installation
+The following tools and configurations are maintained in this repository:
 
-```sh
-# Get the app from GitHub
-bench get-app [App Name] https://github.com/Ambibuzz/[App Name].git
+### 1. Python Linting & Formatting (`ruff.toml`)
 
-# Install the app on your site
-bench --site [your-site] install-app [App Name]
+We use **Ruff** for extremely fast Python linting and formatting.
+
+- **Config File**: [`ruff.toml`](ruff.toml)
+- **Settings**:
+  - Target Python Version: 3.10
+  - Line Length: 110
+  - Indent Style: Tab
+  - Rules: Flake8 (F), pycodestyle (E, W), isort (I), pyupgrade (UP), bugbear (B), and Ruff specific rules (RUF).
+
+### 2. Commit Message Linting (`commitlint.config.js`)
+
+We enforce **Conventional Commits** to ensure a clean and structured commit history.
+
+- **Config File**: [`commitlint.config.js`](commitlint.config.js)
+- **Standard**: Conventional Commits (via `@commitlint/config-conventional`)
+
+### 3. Pre-commit Hooks (`.pre-commit-config.yaml`)
+
+A set of Git hooks to automatically identify and fix issues before code is committed.
+
+- **Config File**: [`.pre-commit-config.yaml`](.pre-commit-config.yaml)
+- **Hooks**:
+  - `trailing-whitespace`
+  - `end-of-file-fixer`
+  - `check-yaml`, `check-json`, `check-toml`
+  - `ruff-check` & `ruff-format` (Python)
+  - `prettier` (JS, CSS, SCSS, etc.)
+  - `commitlint` (Commit messages)
+
+## Setup
+
+To ensure code quality and consistency, please set up the Git hooks locally:
+
+1. **Install `pre-commit`**:
+
+   ```bash
+   pip install pre-commit
+   ```
+
+2. **Install the hooks**:
+   ```bash
+   pre-commit install
+   pre-commit install --hook-type commit-msg
+   ```
+
+## Workflows
+
+GitHub Actions workflows are located in `.github/workflows/` and can be used for checking code quality across repositories.
+
+- **`pylint.yml`**: Runs Pylint checks.
+- **`jslint.yml`**: Runs JavaScript linting.
+- **`review.yml`**: General review workflow.
+
+## Templates
+
+- **Pull Request Template**: Located at `.github/PULL_REQUEST_TEMPLATE.md`, this template is automatically applied to new Pull Requests in the organization to guide contributors in providing necessary context.
+
+- **Repository Structure**:A quick overview of the key files and folders:
+```
+├── .github/
+│   ├── workflows/
+│   │   ├── pylint.yml
+│   │   ├── jslint.yml
+│   │   └── review.yml
+│   └── PULL_REQUEST_TEMPLATE.md
+├── .pre-commit-config.yaml
+├── commitlint.config.js
+├── ruff.toml
+└── README.md
 ```
 
-## Setup & Configuration
+## license
 
-- Ensure you have a Frappe site running.
-- Install dependencies (if any) using `bench setup requirements`.
-- Run `bench migrate` to apply database changes.
-- Configure settings via the app's configuration page in Frappe.
-
-## Development
-
-### Prerequisites
-
-- Frappe Framework v15+
-- Python 3.10+
-- Node.js 18+
-- Redis, MariaDB, and other Frappe dependencies
-
-### Setting Up for Development
-
-```sh
-# Clone the repository
-cd apps
-
-git clone https://github.com/Ambibuzz/[App Name].git
-
-# Install the app
-bench get-app [App Name]
-bench --site [your-site] install-app [App Name]
-```
-
-## Contributing
-
-We welcome contributions! Please follow these steps:
-
-1. Fork the repository on GitHub.
-2. Create a feature branch.
-3. Commit changes with clear commit messages.
-4. Push to your fork and create a pull request.
-
-## License
-
-[App Name] is licensed under the MIT License.
+MIT
 
 ## Maintainers
 
@@ -71,4 +111,3 @@ This application is actively maintained by **Ambibuzz Technologies LLP**. For an
 - GitHub: [Ambibuzz](https://github.com/Ambibuzz)
 - Website: [ambibuzz.com](https://www.ambibuzz.com)
 - Email: [buzz.us@ambibuzz.com](mailto:buzz.us@ambibuzz.com)
-

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+	extends: ["@commitlint/config-conventional"],
+
+	rules: {
+		"type-enum": [
+			2,
+			"always",
+			["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"],
+		],
+		"subject-empty": [2, "never"],
+		"subject-case": [0],
+		"type-case": [2, "always", "lower-case"],
+		"type-empty": [2, "never"],
+		"signed-off-by": [2, "always", "Signed-off-by"],
+	},
+};

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,25 @@
+
+line-length = 110
+target-version = "py310"
+exclude = ["node_modules", ".git", "env", "venv"]
+
+[lint]
+select = [
+    "F",
+    "E",
+    "W",
+    "I",
+    "UP",
+    "B",
+    "RUF",
+]
+ignore = [
+    "W191", # indentation contains tabs
+    "RUF001", # string contains ambiguous unicode character
+    "E101", # indentation contains mixed spaces and tabs
+]
+
+[format]
+quote-style = "double"
+indent-style = "tab"
+docstring-code-format = true


### PR DESCRIPTION
- **Ruff** for Python linting
- **pre-commit hooks** to enforce code standards automatically
- **Commitlint** to standardize commit messages

Additionally, the README has been updated to document these tools, and the `.flake8` file has been removed.

